### PR TITLE
Update color of ignored resources

### DIFF
--- a/themes/Lina-color-theme.json
+++ b/themes/Lina-color-theme.json
@@ -2036,7 +2036,7 @@
 	  "gitDecoration.addedResourceForeground": "#28bc3799",
 	  "gitDecoration.conflictingResourceForeground": "#9c56f399",
 	  "gitDecoration.deletedResourceForeground": "#f95d4799",
-	  "gitDecoration.ignoredResourceForeground": "#ffffff60",
+	  "gitDecoration.ignoredResourceForeground": "#ffffff40",
 	  "gitDecoration.modifiedResourceForeground": "#febc6499",
 	  "gitDecoration.stageDeletedResourceForeground": "#f95d4799",
 	  "gitDecoration.stageModifiedResourceForeground": "#febc6499",


### PR DESCRIPTION
Changed the color of ignored resources to be a little less opaque (and different from non-ignored resources).

Before:
<img src="https://github.com/user-attachments/assets/39aa7dde-165d-4971-b4d7-d326505f066a" alt="91553" width=50% height=50%/>

After:
<img src="https://github.com/user-attachments/assets/83348cb9-96a5-4823-b3a8-d00c740c1fef" alt="39806" width=50% height=50%/>